### PR TITLE
[TEST] Set scheduled and triggered runs for SPIRE CI

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,5 +1,10 @@
 name: PR Build
-on: [pull_request]
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+  schedule:
+    # Random minute number to avoid GH scheduler stampede
+    - cron: '37 21 * * *'
 env:
   GO_VERSION: 1.16.3
 jobs:


### PR DESCRIPTION
This commit updates the GitHub Actions workflow for SPIRE CI to trigger
one run daily against the main branch, and expose the option to manually
trigger runs.

Even though every PR gets fully tested, and we require PRs to be
up-to-date prior to merging, we need this because:
* GH UI won't allow you to block merge on action status that is not run
  directly against main branch
* GH Actions status badge will not reflect status without GH Action
  being run directly against main branch
* It is convenient to be able to trigger builds against main manually,
  e.g. if a commit to fix the build has just merged and we want to flip
  to green

Signed-off-by: Evan Gilman <egilman@vmware.com>